### PR TITLE
fixes typeerror in hipparcos function

### DIFF
--- a/skyfield/data/hipparcos.py
+++ b/skyfield/data/hipparcos.py
@@ -26,7 +26,8 @@ def parse(line):
 
 def load(is_match, cache=default_cache):
     with cache.open_url(url, days_old=9999) as f:
-        for line in gzip.open(f):
+        data = gzip.GzipFile(fileobj=f)
+        for line in data.readlines():
             id = line[8:14]
             if is_match(id):
                 yield parse(line)


### PR DESCRIPTION
`gzip.open()` was erroring as seen in Issue #35 when used like `gzip.open(f)`. It works okay if passed the downloaded file, such as `gzip.open('hip_main.dat.gz')`. I understand this is just a shorthand, but it was happening anyhow. My solution is to use `gzip.GzipFile(fileobj=f)` instead, and use `readlines()`.

```
import gzip
from skyfield.data import hipparcos
from skyfield.data import cache as default_cache
url = 'ftp://cdsarc.u-strasbg.fr/cats/I/239/hip_main.dat.gz'

def load2(is_match, cache=default_cache):
    with cache.open_url(url, days_old=9999) as f:
        data = gzip.GzipFile(fileobj=f)
        #data = gzip.open('hip_main.dat.gz')
        for line in data.readlines():
            id = line[8:14]
            if is_match(id):
               yield hipparcos.parse(line)
                
which = '11767'
is_match = which.rjust(6).encode('ascii').__eq__
for star in load2(is_match):
    s = star
    print(s)
    
print((s.ra, s.dec))
```