### PR TITLE
Adds error message for accidental tuple and expands JulianDate's docstring

### DIFF
--- a/skyfield/tests/test_timelib.py
+++ b/skyfield/tests/test_timelib.py
@@ -2,7 +2,7 @@ import numpy as np
 from assay import assert_raises
 from pytz import timezone
 from skyfield.constants import DAY_S
-from skyfield.timelib import JulianDate, utc
+from skyfield.timelib import JulianDate, takes_julian_date, utc
 from datetime import datetime
 
 one_second = 1.0 / DAY_S
@@ -10,6 +10,16 @@ epsilon = one_second * 42.0e-6  # 20.1e-6 is theoretical best precision
 
 time_parameter = ['tai', 'tt', 'tdb']
 time_value = [(1973, 1, 18, 1, 35, 37.5), 2441700.56640625]
+
+def test_tuple_error_raised():
+    def fake_function():
+        """ The decorator requires a docstring. """
+    decorated_function = takes_julian_date(fake_function)
+    tuple_argument = (2014, 1, 23)
+    self = None
+    with assert_raises(ValueError) as info:
+        decorated_function(self, tuple_argument)
+    assert 'Are you trying to pass in a tuple' in str(info.exception)
 
 def test_JulianDate_init(time_parameter, time_value):
     kw = {time_parameter: time_value}

--- a/skyfield/timelib.py
+++ b/skyfield/timelib.py
@@ -69,7 +69,7 @@ def takes_julian_date(function):
         if jd is None:
             jd = JulianDate(utc, tai, tt, tdb, delta_t, cache)
         elif not isinstance(jd, JulianDate):
-            if not isinstance(jd, tuple):
+            if isinstance(jd, tuple):
                 s = _tuple_error
             else:
                 s = 'your "jd" argument is not a JulianDate: {0!r}'.format(jd)

--- a/skyfield/timelib.py
+++ b/skyfield/timelib.py
@@ -106,7 +106,7 @@ class JulianDate(object):
     date of the current date and time, use the separate function
     ``skyfield.api.now()``.
 
-    Every Julian date object understands five different time scales,
+    Every Julian date object understands four different time scales,
     which can be used during instantiation::
 
         JulianDate(utc=(year, month, day, hour, minute, second))
@@ -114,7 +114,6 @@ class JulianDate(object):
         JulianDate(tai=(year, month, day, ...) or float)
         JulianDate(tt=(year, month, day, ...) or float)
         JulianDate(tdb=(year, month, day, ...) or float)
-        JulianDate(ut1=(year, month, day, ...) or float)
 
     """
     def __init__(self, utc=None, tai=None, tt=None, tdb=None,

--- a/skyfield/timelib.py
+++ b/skyfield/timelib.py
@@ -87,7 +87,9 @@ accompany tuples. For example:
 
     utc=(2014, 1, 18)
 
-Other time scales include tai, tt, tdb, and ut1.
+Other time scales include tai, tt, and tdb. Please refer to the
+```JulianDate``` docstring for more information on these time scales.
+
 """
 
 def _to_array(value):
@@ -109,11 +111,22 @@ class JulianDate(object):
     Every Julian date object understands four different time scales,
     which can be used during instantiation::
 
+        # Coordinated Universal Time
         JulianDate(utc=(year, month, day, hour, minute, second))
-                       or Standard Library datetime or date)
-        JulianDate(tai=(year, month, day, ...) or float)
-        JulianDate(tt=(year, month, day, ...) or float)
-        JulianDate(tdb=(year, month, day, ...) or float)
+        JulianDate(utc=datetime(year, month, day, hour, minute, second))
+        JulianDate(utc=date(year, month, day))
+
+        # International Atomic Time
+        JulianDate(tai=2442046.5)  <- Julian day represented by a float
+        JulianDate(tai=(year, month, day, hour, minute, second))
+
+        # Terrestrial Time
+        JulianDate(tt=2442046.5)  <- Julian day represented by a float
+        JulianDate(tt=(year, month, day, hour, minute, second))
+
+        # Barycentric Dynamical Time
+        JulianDate(tdb=2442046.5)  <- Julian day represented by a float
+        JulianDate(tdb=(year, month, day, hour, minute, second))
 
     """
     def __init__(self, utc=None, tai=None, tt=None, tdb=None,

--- a/skyfield/timelib.py
+++ b/skyfield/timelib.py
@@ -69,13 +69,26 @@ def takes_julian_date(function):
         if jd is None:
             jd = JulianDate(utc, tai, tt, tdb, delta_t, cache)
         elif not isinstance(jd, JulianDate):
-            s = 'your "jd" argument is not a JulianDate: {0!r}'.format(jd)
+            if not isinstance(jd, tuple):
+                s = _tuple_error
+            else:
+                s = 'your "jd" argument is not a JulianDate: {0!r}'.format(jd)
             raise ValueError(s)
         return function(self, jd)
     wrapper.__name__ = function.__name__
     synopsis, blank_line, description = function.__doc__.partition('\n\n')
     wrapper.__doc__ = synopsis + extra_documentation + description
     return wrapper
+
+_tuple_error = """was expecting a JulianDate.
+
+Are you trying to pass in a tuple to represent a time? A time scale must
+accompany tuples. For example:
+
+    utc=(2014, 1, 18)
+
+Other time scales include tai, tt, tdb, and ut1.
+"""
 
 def _to_array(value):
     """When `value` is a plain Python sequence, return it as a NumPy array."""


### PR DESCRIPTION
- new error message for when a tuple is accidentally passed into a function wrapped with takes_julian_date decorator

- adds test to ensure that this new tuple error message is the exception raised

- more documentation to JulianDate to link the time scale abbreviations to full names, as well as mentioning that the float is a Julian day representation.

- removed references to ut1 / the fifth time scale (ut1 was removed long ago, but the docstring still referenced it)